### PR TITLE
Task.6-3 model の validation テストの実装

### DIFF
--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -1,4 +1,8 @@
 class Article < ApplicationRecord
+  # titleは100文字以内の制限をかける
+  validates :title, presence: true, length: { maximum: 100 }
+  validates :body, presence: true
+
   has_many :comments, dependent: :destroy
   has_many :article_likes, dependent: :destroy
   belongs_to :user

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -1,4 +1,6 @@
 class Comment < ApplicationRecord
+  validates :content, presence: true
+
   belongs_to :user
   belongs_to :article
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -7,6 +7,16 @@ class User < ApplicationRecord
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :trackable, :validatable
   include DeviseTokenAuth::Concerns::User
+
+  # パスワードはアルファベットと数字の混合のみ可能にし、文字数制限は8〜32字以内とする
+  VALID_PASSWORD_REGEX = /\A(?=.*?[a-z])[a-z\d]{8,32}+\z/
+  validates :password, presence: true, length: { minimum: 8, maximum: 32}, format: { with: VALID_PASSWORD_REGEX}
+  # emailは＠と.の使用を必須にする
+  VALID_EMAIL_REGEX = /\A([\w+\-].?)+@[a-z\d\-]+(\.[a-z]+)*\.[a-z]+\z/
+  validates :email, presence: true, uniqueness: true, format: {with: VALID_EMAIL_REGEX}
+  validates :name, presence: true
+  validates :account, presence: true, uniqueness: true
+
   has_many :articles, dependent: :destroy
   has_many :comments, dependent: :destroy
   has_many :article_likes, dependent: :destroy

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -9,7 +9,7 @@ class User < ApplicationRecord
   include DeviseTokenAuth::Concerns::User
 
   # パスワードはアルファベット半角大文字小文字と数字の混合のみ可能にし、文字数制限は8〜32字以内とする
-  VALID_PASSWORD_REGEX = /\A(?=.*?[a-z])(?=.*?[A-Z])(?=.*?\d)[a-zA-Z\d]{8,32}+\z/
+  VALID_PASSWORD_REGEX = /\A(?=.*?[a-z])(?=.*?[A-Z])(?=.*?\d)[a-zA-Z\d]{8,32}\z/
   validates :password, presence: true, format: { with: VALID_PASSWORD_REGEX}
   # emailは＠と.の使用を必須にする
   VALID_EMAIL_REGEX = /\A([\w+\-].?)+@[a-z\d\-]+(\.[a-z]+)*\.[a-z]+\z/

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -9,11 +9,11 @@ class User < ApplicationRecord
   include DeviseTokenAuth::Concerns::User
 
   # パスワードはアルファベット半角大文字小文字と数字の混合のみ可能にし、文字数制限は8〜32字以内とする
-  VALID_PASSWORD_REGEX = /\A(?=.*?[a-z])(?=.*?[A-Z])(?=.*?\d)[a-zA-Z\d]{8,32}\z/
-  validates :password, presence: true, format: { with: VALID_PASSWORD_REGEX}
+  VALID_PASSWORD_REGEX = /\A(?=.*?[a-z])(?=.*?[A-Z])(?=.*?\d)[a-zA-Z\d]{8,32}\z/.freeze
+  validates :password, presence: true, format: { with: VALID_PASSWORD_REGEX }
   # emailは＠と.の使用を必須にする
-  VALID_EMAIL_REGEX = /\A([\w+\-].?)+@[a-z\d\-]+(\.[a-z]+)*\.[a-z]+\z/
-  validates :email, presence: true, uniqueness: true, format: {with: VALID_EMAIL_REGEX}
+  VALID_EMAIL_REGEX = /\A([\w+\-].?)+@[a-z\d\-]+(\.[a-z]+)*\.[a-z]+\z/.freeze
+  validates :email, presence: true, uniqueness: true, format: { with: VALID_EMAIL_REGEX }
   validates :name, presence: true
   validates :account, presence: true, uniqueness: true
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -8,9 +8,9 @@ class User < ApplicationRecord
          :recoverable, :rememberable, :trackable, :validatable
   include DeviseTokenAuth::Concerns::User
 
-  # パスワードはアルファベットと数字の混合のみ可能にし、文字数制限は8〜32字以内とする
-  VALID_PASSWORD_REGEX = /\A(?=.*?[a-z])[a-z\d]{8,32}+\z/
-  validates :password, presence: true, length: { minimum: 8, maximum: 32}, format: { with: VALID_PASSWORD_REGEX}
+  # パスワードはアルファベット半角大文字小文字と数字の混合のみ可能にし、文字数制限は8〜32字以内とする
+  VALID_PASSWORD_REGEX = /\A(?=.*?[a-z])(?=.*?[A-Z])(?=.*?\d)[a-zA-Z\d]{8,32}+\z/
+  validates :password, presence: true, format: { with: VALID_PASSWORD_REGEX}
   # emailは＠と.の使用を必須にする
   VALID_EMAIL_REGEX = /\A([\w+\-].?)+@[a-z\d\-]+(\.[a-z]+)*\.[a-z]+\z/
   validates :email, presence: true, uniqueness: true, format: {with: VALID_EMAIL_REGEX}

--- a/spec/factories/article_likes.rb
+++ b/spec/factories/article_likes.rb
@@ -1,4 +1,6 @@
 FactoryBot.define do
   factory :article_like do
+    user
+    article
   end
 end

--- a/spec/factories/articles.rb
+++ b/spec/factories/articles.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
   factory :article do
-    title { Faker::Lorem.characters(number: Random.new.rand(1..100) }
+    title { Faker::Lorem.characters(number: Random.new.rand(1..100)) }
     body { Faker::Lorem.paragraph(sentence_count: 20) }
     user
   end

--- a/spec/factories/articles.rb
+++ b/spec/factories/articles.rb
@@ -1,6 +1,7 @@
 FactoryBot.define do
   factory :article do
-    title { "" }
-    body { "" }
+    title { Faker::Lorem.characters(number: Random.new.rand(1..100) }
+    body { Faker::Lorem.paragraph(sentence_count: 20) }
+    user
   end
 end

--- a/spec/factories/comments.rb
+++ b/spec/factories/comments.rb
@@ -1,5 +1,7 @@
 FactoryBot.define do
   factory :comment do
-    content { "" }
+    content { Faker::Lorem.paragraph(sentence_count: 2) }
+    user
+    article
   end
 end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -1,0 +1,5 @@
+FactoryBot.define do
+  factory :user do
+    
+  end
+end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -1,8 +1,8 @@
 FactoryBot.define do
   factory :user do
     name { Faker::Name.name }
-    sequence(:account) { |n| "#{n}_#{Faker::Internet.username}" }
-    sequence(:email) { |n| "#{n}_#{Faker::Internet.email}" }
+    sequence(:account) {|n| "#{n}_#{Faker::Internet.username}" }
+    sequence(:email) {|n| "#{n}_#{Faker::Internet.email}" }
     password { Faker::Internet.password(min_length: 8, max_length: 32, mix_case: true) }
   end
 end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -1,5 +1,8 @@
 FactoryBot.define do
   factory :user do
-    
+    name { Faker::Name.name }
+    sequence(:account) { |n| "#{n}_#{Faker::Internet.username}" }
+    sequence(:email) { |n| "#{n}_#{Faker::Internet.email}" }
+    password { Faker::Internet.password(min_length: 8, max_length: 32, mix_case: true) }
   end
 end

--- a/spec/models/article_spec.rb
+++ b/spec/models/article_spec.rb
@@ -3,7 +3,7 @@ require "rails_helper"
 RSpec.describe Article, type: :model do
   describe "正常系" do
     context "タイトルと本文が条件通りに入力されている時" do
-      let(:article){build(:article)}
+      let(:article) { build(:article) }
       it "記事が保存できる" do
         expect(article).to be_valid
       end
@@ -12,24 +12,26 @@ RSpec.describe Article, type: :model do
 
   describe "異常系" do
     context "タイトルの文字数が100字より多いとき" do
-      let(:article){build(:article, title: Faker::Lorem.characters(number: 101))}
+      let(:article) { build(:article, title: Faker::Lorem.characters(number: 101)) }
       it "記事が保存できない" do
         article.valid?
         expect(article.errors.messages[:title]).to include "is too long (maximum is 100 characters)"
       end
     end
+
     context "タイトルを入力していないとき" do
-        let(:article){build(:article,title: nil)}
-        it "記事が保存できない" do
+      let(:article) { build(:article, title: nil) }
+      it "記事が保存できない" do
         article.valid?
         expect(article.errors.messages[:title]).to include "can't be blank"
       end
     end
+
     context "本文を入力していないとき" do
-      let(:article){build(:article,body: nil)}
+      let(:article) { build(:article, body: nil) }
       it "記事が保存できない" do
-      article.valid?
-      expect(article.errors.messages[:body]).to include "can't be blank"
+        article.valid?
+        expect(article.errors.messages[:body]).to include "can't be blank"
       end
     end
   end

--- a/spec/models/article_spec.rb
+++ b/spec/models/article_spec.rb
@@ -1,5 +1,36 @@
 require "rails_helper"
 
 RSpec.describe Article, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
+  describe "正常系" do
+    context "タイトルと本文が条件通りに入力されている時" do
+      let(:article){build(:article)}
+      it "記事が保存できる" do
+        expect(article).to be_valid
+      end
+    end
+  end
+
+  describe "異常系" do
+    context "タイトルの文字数が100字より多いとき" do
+      let(:article){build(:article, title: Faker::Lorem.characters(number: 101))}
+      it "記事が保存できない" do
+        article.valid?
+        expect(article.errors.messages[:title]).to include "is too long (maximum is 100 characters)"
+      end
+    end
+    context "タイトルを入力していないとき" do
+        let(:article){build(:article,title: nil)}
+        it "記事が保存できない" do
+        article.valid?
+        expect(article.errors.messages[:title]).to include "can't be blank"
+      end
+    end
+    context "本文を入力していないとき" do
+      let(:article){build(:article,body: nil)}
+      it "記事が保存できない" do
+      article.valid?
+      expect(article.errors.messages[:body]).to include "can't be blank"
+      end
+    end
+  end
 end

--- a/spec/models/comment_spec.rb
+++ b/spec/models/comment_spec.rb
@@ -1,5 +1,23 @@
 require "rails_helper"
 
 RSpec.describe Comment, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
+  describe "正常系" do
+    context "内容が入力されている時" do
+      let(:comment){build(:comment)}
+      it "コメントが保存できる" do
+        expect(comment).to be_valid
+      end
+    end
+  end
+
+  describe "異常系" do
+    context "本文を入力していないとき" do
+      let(:comment){build(:comment,content: nil)}
+      it "記事が保存できない" do
+      comment.valid?
+      expect(comment.errors.messages[:content]).to include "can't be blank"
+      end
+    end
+  end
+
 end

--- a/spec/models/comment_spec.rb
+++ b/spec/models/comment_spec.rb
@@ -3,7 +3,7 @@ require "rails_helper"
 RSpec.describe Comment, type: :model do
   describe "正常系" do
     context "内容が入力されている時" do
-      let(:comment){build(:comment)}
+      let(:comment) { build(:comment) }
       it "コメントが保存できる" do
         expect(comment).to be_valid
       end
@@ -12,12 +12,11 @@ RSpec.describe Comment, type: :model do
 
   describe "異常系" do
     context "本文を入力していないとき" do
-      let(:comment){build(:comment,content: nil)}
+      let(:comment) { build(:comment, content: nil) }
       it "記事が保存できない" do
-      comment.valid?
-      expect(comment.errors.messages[:content]).to include "can't be blank"
+        comment.valid?
+        expect(comment.errors.messages[:content]).to include "can't be blank"
       end
     end
   end
-
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe User, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe User, type: :model do
 
   describe "異常系" do
     context "passwordの文字数が8字より少ないとき" do
-      let(:user) { build(:user, password: "12CDef7") }
+      let(:user) { build(:user, password: Faker::Internet.password(max_length: 7, mix_case: true)) }
       it "エラーになる" do
         user.valid?
         expect(user.errors.messages[:password]).to include "is invalid"

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -12,18 +12,17 @@ RSpec.describe User, type: :model do
 
   describe "異常系" do
     context "passwordの文字数が8字より少ないとき" do
-      let(:user){build(:user, password: "12CDef")}
+      let(:user){build(:user, password: "12CDef7")}
       it "エラーになる" do
         user.valid?
-        #binding.pry
-        expect(user.errors.messages[:password]).to include "Password is too short (minimum is 8 characters)"
+        expect(user.errors.messages[:password]).to include "is invalid"
       end
     end
     context "passwordの文字数が32字より多いとき" do
       let(:user){build(:user, password: Faker::Internet.password(min_length: 33, mix_case: true))}
       it "エラーになる" do
         user.valid?
-        expect(user.errors.messages[:password]).to include "Password is too long (maximum is 32 characters)"
+        expect(user.errors.messages[:password]).to include "is invalid"
       end
     end
     context "passwordに数字が入っていないとき" do
@@ -47,39 +46,66 @@ RSpec.describe User, type: :model do
         expect(user.errors.messages[:password]).to include "is invalid"
       end
     end
-
-    context "タイトルを入力していないとき" do
-        let(:article){build(:article,title: nil)}
-        it "記事が保存できない" do
-        article.valid?
-        expect(article.errors.messages[:title]).to include "can't be blank"
+    context "passwordが入力されていないとき" do
+      let(:user){build(:user, password: nil)}
+      it "登録できない" do
+        user.valid?
+        expect(user.errors.messages[:password]).to include "can't be blank"
       end
     end
-    context "本文を入力していないとき" do
-      let(:article){build(:article,body: nil)}
-      it "記事が保存できない" do
-      article.valid?
-      expect(article.errors.messages[:body]).to include "can't be blank"
+
+    context "emailに@を入力していないとき" do
+      let(:user){build(:user,email: "1234asdf.co.jp")}
+        it "エラーになる" do
+        user.valid?
+        expect(user.errors.messages[:email]).to include "is invalid"
       end
     end
-  end
-
-  context "account を指定していないとき" do
-    it "エラーする" do
-      user = build(:user,account: nil)
-      user.valid?
-
-      expect(user.errors.messages[:account]).to include "can't be blank"
+    context "emailに.を入力していないとき" do
+      let(:user){build(:user,email: "1234abcdf@cojp")}
+        it "エラーになる" do
+        user.valid?
+        expect(user.errors.messages[:email]).to include "is invalid"
+      end
     end
-  end
+    context "同一のemailが既に存在するとき" do
+      before {create(:user,email: "1234abcdf@co.jp")}
+      let(:user){build(:user,email: "1234abcdf@co.jp")}
+        it "登録できない" do
+        user.valid?
+        expect(user.errors.messages[:email]).to include "has already been taken"
+      end
+    end
+    context "emailが入力されていないとき" do
+      let(:user){build(:user, email: nil)}
+      it "登録できない" do
+        user.valid?
+        expect(user.errors.messages[:email]).to include "can't be blank"
+      end
+    end
 
-  context "同名のaccountが存在するとき" do
-    it "エラーする" do
-      create(:user,account: "taka")
-      user = build(:user,account: "taka")
-      user.valid?
+    context "nameが入力されていないとき" do
+      let(:user){build(:user, name: nil)}
+      it "登録できない" do
+        user.valid?
+        expect(user.errors.messages[:name]).to include "can't be blank"
+      end
+    end
 
-      expect(user.errors.messages[:account]).to include "has already been taken"
+    context "同一のaccountが既に存在するとき" do
+      before {create(:user,account: "taka")}
+      let(:user){build(:user,account: "taka")}
+        it "登録できない" do
+        user.valid?
+        expect(user.errors.messages[:account]).to include "has already been taken"
+      end
+    end
+    context "accountが入力されていないとき" do
+      let(:user){build(:user, account: nil)}
+      it "登録できない" do
+        user.valid?
+        expect(user.errors.messages[:account]).to include "can't be blank"
+      end
     end
   end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1,9 +1,9 @@
-require 'rails_helper'
+require "rails_helper"
 
 RSpec.describe User, type: :model do
   describe "正常系" do
     context "ユーザ情報が条件通りに入力されている時" do
-      let(:user){build(:user)}
+      let(:user) { build(:user) }
       it "ユーザ登録できる" do
         expect(user).to be_valid
       end
@@ -12,42 +12,47 @@ RSpec.describe User, type: :model do
 
   describe "異常系" do
     context "passwordの文字数が8字より少ないとき" do
-      let(:user){build(:user, password: "12CDef7")}
+      let(:user) { build(:user, password: "12CDef7") }
       it "エラーになる" do
         user.valid?
         expect(user.errors.messages[:password]).to include "is invalid"
       end
     end
+
     context "passwordの文字数が32字より多いとき" do
-      let(:user){build(:user, password: Faker::Internet.password(min_length: 33, mix_case: true))}
+      let(:user) { build(:user, password: Faker::Internet.password(min_length: 33, mix_case: true)) }
       it "エラーになる" do
         user.valid?
         expect(user.errors.messages[:password]).to include "is invalid"
       end
     end
+
     context "passwordに数字が入っていないとき" do
-      let(:user){build(:user, password: "ABCDefgh")}
+      let(:user) { build(:user, password: "ABCDefgh") }
       it "エラーになる" do
         user.valid?
         expect(user.errors.messages[:password]).to include "is invalid"
       end
     end
+
     context "passwordにアルファベット半角大文字が入っていないとき" do
-      let(:user){build(:user, password: "1234efgh")}
+      let(:user) { build(:user, password: "1234efgh") }
       it "エラーになる" do
         user.valid?
         expect(user.errors.messages[:password]).to include "is invalid"
       end
     end
+
     context "passwordにアルファベット半角小文字が入っていないとき" do
-      let(:user){build(:user, password: "1234EFGH")}
+      let(:user) { build(:user, password: "1234EFGH") }
       it "エラーになる" do
         user.valid?
         expect(user.errors.messages[:password]).to include "is invalid"
       end
     end
+
     context "passwordが入力されていないとき" do
-      let(:user){build(:user, password: nil)}
+      let(:user) { build(:user, password: nil) }
       it "登録できない" do
         user.valid?
         expect(user.errors.messages[:password]).to include "can't be blank"
@@ -55,29 +60,33 @@ RSpec.describe User, type: :model do
     end
 
     context "emailに@を入力していないとき" do
-      let(:user){build(:user,email: "1234asdf.co.jp")}
-        it "エラーになる" do
+      let(:user) { build(:user, email: "1234asdf.co.jp") }
+      it "エラーになる" do
         user.valid?
         expect(user.errors.messages[:email]).to include "is invalid"
       end
     end
+
     context "emailに.を入力していないとき" do
-      let(:user){build(:user,email: "1234abcdf@cojp")}
-        it "エラーになる" do
+      let(:user) { build(:user, email: "1234abcdf@cojp") }
+      it "エラーになる" do
         user.valid?
         expect(user.errors.messages[:email]).to include "is invalid"
       end
     end
+
     context "同一のemailが既に存在するとき" do
-      before {create(:user,email: "1234abcdf@co.jp")}
-      let(:user){build(:user,email: "1234abcdf@co.jp")}
-        it "登録できない" do
+      before { create(:user, email: "1234abcdf@co.jp") }
+
+      let(:user) { build(:user, email: "1234abcdf@co.jp") }
+      it "登録できない" do
         user.valid?
         expect(user.errors.messages[:email]).to include "has already been taken"
       end
     end
+
     context "emailが入力されていないとき" do
-      let(:user){build(:user, email: nil)}
+      let(:user) { build(:user, email: nil) }
       it "登録できない" do
         user.valid?
         expect(user.errors.messages[:email]).to include "can't be blank"
@@ -85,7 +94,7 @@ RSpec.describe User, type: :model do
     end
 
     context "nameが入力されていないとき" do
-      let(:user){build(:user, name: nil)}
+      let(:user) { build(:user, name: nil) }
       it "登録できない" do
         user.valid?
         expect(user.errors.messages[:name]).to include "can't be blank"
@@ -93,15 +102,17 @@ RSpec.describe User, type: :model do
     end
 
     context "同一のaccountが既に存在するとき" do
-      before {create(:user,account: "taka")}
-      let(:user){build(:user,account: "taka")}
-        it "登録できない" do
+      before { create(:user, account: "taka") }
+
+      let(:user) { build(:user, account: "taka") }
+      it "登録できない" do
         user.valid?
         expect(user.errors.messages[:account]).to include "has already been taken"
       end
     end
+
     context "accountが入力されていないとき" do
-      let(:user){build(:user, account: nil)}
+      let(:user) { build(:user, account: nil) }
       it "登録できない" do
         user.valid?
         expect(user.errors.messages[:account]).to include "can't be blank"

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1,5 +1,85 @@
 require 'rails_helper'
 
 RSpec.describe User, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
+  describe "正常系" do
+    context "ユーザ情報が条件通りに入力されている時" do
+      let(:user){build(:user)}
+      it "ユーザ登録できる" do
+        expect(user).to be_valid
+      end
+    end
+  end
+
+  describe "異常系" do
+    context "passwordの文字数が8字より少ないとき" do
+      let(:user){build(:user, password: "12CDef")}
+      it "エラーになる" do
+        user.valid?
+        #binding.pry
+        expect(user.errors.messages[:password]).to include "Password is too short (minimum is 8 characters)"
+      end
+    end
+    context "passwordの文字数が32字より多いとき" do
+      let(:user){build(:user, password: Faker::Internet.password(min_length: 33, mix_case: true))}
+      it "エラーになる" do
+        user.valid?
+        expect(user.errors.messages[:password]).to include "Password is too long (maximum is 32 characters)"
+      end
+    end
+    context "passwordに数字が入っていないとき" do
+      let(:user){build(:user, password: "ABCDefgh")}
+      it "エラーになる" do
+        user.valid?
+        expect(user.errors.messages[:password]).to include "is invalid"
+      end
+    end
+    context "passwordにアルファベット半角大文字が入っていないとき" do
+      let(:user){build(:user, password: "1234efgh")}
+      it "エラーになる" do
+        user.valid?
+        expect(user.errors.messages[:password]).to include "is invalid"
+      end
+    end
+    context "passwordにアルファベット半角小文字が入っていないとき" do
+      let(:user){build(:user, password: "1234EFGH")}
+      it "エラーになる" do
+        user.valid?
+        expect(user.errors.messages[:password]).to include "is invalid"
+      end
+    end
+
+    context "タイトルを入力していないとき" do
+        let(:article){build(:article,title: nil)}
+        it "記事が保存できない" do
+        article.valid?
+        expect(article.errors.messages[:title]).to include "can't be blank"
+      end
+    end
+    context "本文を入力していないとき" do
+      let(:article){build(:article,body: nil)}
+      it "記事が保存できない" do
+      article.valid?
+      expect(article.errors.messages[:body]).to include "can't be blank"
+      end
+    end
+  end
+
+  context "account を指定していないとき" do
+    it "エラーする" do
+      user = build(:user,account: nil)
+      user.valid?
+
+      expect(user.errors.messages[:account]).to include "can't be blank"
+    end
+  end
+
+  context "同名のaccountが存在するとき" do
+    it "エラーする" do
+      create(:user,account: "taka")
+      user = build(:user,account: "taka")
+      user.valid?
+
+      expect(user.errors.messages[:account]).to include "has already been taken"
+    end
+  end
 end


### PR DESCRIPTION
## 概要
1. 各model に必要な validation をリストアップする
→下記issueにvalidationの設定をリストアップ。
https://github.com/takafumi0225/qiita_clone/issues/11

2. 各model に validation を追加する

3. 各model に追加した validation のテストを実装する
→passwordの文字数テストが通らなかったため、下記issueに対応をまとめた。
https://github.com/takafumi0225/qiita_clone/issues/12