### PR TITLE
Task.7 Article に関する API 実装(1〜3まで)

### DIFF
--- a/app/controllers/api/v1/api_controller.rb
+++ b/app/controllers/api/v1/api_controller.rb
@@ -1,0 +1,3 @@
+class Api::V1::ApiController < ActionController::Base
+  include DeviseTokenAuth::Concerns::SetUserByToken
+end

--- a/app/controllers/api/v1/api_controller.rb
+++ b/app/controllers/api/v1/api_controller.rb
@@ -1,3 +1,0 @@
-class Api::V1::ApiController < ActionController::Base
-  include DeviseTokenAuth::Concerns::SetUserByToken
-end

--- a/app/controllers/api/v1/articles_controller.rb
+++ b/app/controllers/api/v1/articles_controller.rb
@@ -1,0 +1,6 @@
+class Api::V1::ArticlesController < Api::V1::ApiController
+  def index
+    articles = Article.all
+    render json: articles
+  end
+end

--- a/app/controllers/api/v1/articles_controller.rb
+++ b/app/controllers/api/v1/articles_controller.rb
@@ -1,4 +1,4 @@
-class Api::V1::ArticlesController < Api::V1::ApiController
+class Api::V1::ArticlesController < Api::V1::BaseApiController
   def index
     articles = Article.all
     render json: articles

--- a/app/controllers/api/v1/base_api_controller.rb
+++ b/app/controllers/api/v1/base_api_controller.rb
@@ -1,0 +1,3 @@
+class Api::V1::BaseApiController < ActionController::Base
+  include DeviseTokenAuth::Concerns::SetUserByToken
+end

--- a/app/serializers/article_serializer.rb
+++ b/app/serializers/article_serializer.rb
@@ -1,0 +1,3 @@
+class ArticleSerializer < ActiveModel::Serializer
+  attributes :id, :title, :body
+end

--- a/app/serializers/article_serializer.rb
+++ b/app/serializers/article_serializer.rb
@@ -1,3 +1,4 @@
 class ArticleSerializer < ActiveModel::Serializer
   attributes :id, :title, :body
+  belongs_to :user
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,5 @@
 Rails.application.routes.draw do
-  namespace :api, { format: 'json' } do
+  namespace :api, { format: "json" } do
     namespace :v1 do # バージョン1を表している
       resources :articles
       mount_devise_token_auth_for "User", at: "auth"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,8 @@
 Rails.application.routes.draw do
-  mount_devise_token_auth_for "User", at: "auth"
-  # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
+  namespace :api, { format: 'json' } do
+    namespace :v1 do # バージョン1を表している
+      resources :articles
+      mount_devise_token_auth_for "User", at: "auth"
+    end
+  end
 end

--- a/spec/requests/api/v1/articles_spec.rb
+++ b/spec/requests/api/v1/articles_spec.rb
@@ -1,0 +1,17 @@
+require 'rails_helper'
+
+RSpec.describe "Api::V1::Articles", type: :request do
+  describe "GET /api/v1/articles" do
+    subject { get(api_v1_articles_path) }
+    before do
+      create_list(:article, 3)
+    end
+    it "記事の一覧が取得できる" do
+      subject
+      res = JSON.parse(response.body)
+      expect(res.length).to eq 3
+      expect(res[0].keys).to eq ["id","title","body"]
+      expect(response).to have_http_status(200)
+    end
+  end
+end

--- a/spec/requests/api/v1/articles_spec.rb
+++ b/spec/requests/api/v1/articles_spec.rb
@@ -8,11 +8,11 @@ RSpec.describe "Api::V1::Articles", type: :request do
       create_list(:article, 3)
     end
 
-    it "記事の一覧が取得できる" do
+    it "記事の一覧及び記事に紐付くユーザ情報が取得できる" do
       subject
       res = JSON.parse(response.body)
       expect(res.length).to eq 3
-      expect(res[0].keys).to eq ["id", "title", "body"]
+      expect(res[0].keys).to eq ["id", "title", "body", "user"]
       expect(response).to have_http_status(:ok)
     end
   end

--- a/spec/requests/api/v1/articles_spec.rb
+++ b/spec/requests/api/v1/articles_spec.rb
@@ -1,17 +1,19 @@
-require 'rails_helper'
+require "rails_helper"
 
 RSpec.describe "Api::V1::Articles", type: :request do
   describe "GET /api/v1/articles" do
     subject { get(api_v1_articles_path) }
+
     before do
       create_list(:article, 3)
     end
+
     it "記事の一覧が取得できる" do
       subject
       res = JSON.parse(response.body)
       expect(res.length).to eq 3
-      expect(res[0].keys).to eq ["id","title","body"]
-      expect(response).to have_http_status(200)
+      expect(res[0].keys).to eq ["id", "title", "body"]
+      expect(response).to have_http_status(:ok)
     end
   end
 end


### PR DESCRIPTION
### 概要
- 記事に関するAPIのルーティングの実装
`bundle exec rails routes | grep articles` にてルーティングを確認
<img width="1106" alt="スクリーンショット 2019-11-25 17 41 52" src="https://user-images.githubusercontent.com/44473259/69607384-7ee80700-1068-11ea-9147-b2c6c92885f4.png">

- api_controllerの作成
- 記事一覧の作成
- request specにて記事一覧のテスト実施